### PR TITLE
Set ASPNETCORE_ENVIRONMENT to "Development" in Run

### DIFF
--- a/src/build.fsx
+++ b/src/build.fsx
@@ -72,6 +72,7 @@ Target.create "PublishInfrastructure" (fun _ ->
 
 Target.create "Run" (fun _ ->
     let server = async {
+        Environment.setEnvironVar "ASPNETCORE_ENVIRONMENT" "Development"
         Tools.dotnet "watch run" serverSrcPath
     }
     let client = async {


### PR DESCRIPTION
Hi, I guess it's up to you, the advantage: behaves like regular ASP.Net Core projects and like the default launch.json template in VS Code.
Possible disadvantage: behaves differently than previously.
But I think less surprise if it works like the rest of ASP.NET Core samples / templates.