### PR TITLE
Add rollForward option to global.json to enable new minor version of dotnet 6 to work

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100"
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
   }
 }

--- a/src/default/global.json
+++ b/src/default/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100"
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
   }
 }

--- a/src/serverless/global.json
+++ b/src/serverless/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100"
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Right now the template is strictly tied to dotnet 6.0.100, with this option (used in the mainline SAFE stack as well) version like 6.0.300 can be supported