### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Strongly opinionated modification of amazing [SAFE Stack Template](https://safe-
 
 Install SAFEr Template:
 
-    dotnet new --install SAFEr.Template
+    dotnet new install SAFEr.Template
 
 Create new directory for your kick-ass full-stack next-unicorn app:
 


### PR DESCRIPTION
Update the template installation instructions to a new syntax. The --install flag is now deprecated in Dotnet 7