### PR TITLE
CJS => ESM

### DIFF
--- a/src/default/package.json
+++ b/src/default/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "type": "module",
     "scripts": {
         "prestart": "dotnet tool restore",
         "start": "dotnet fable watch ./src/SAFEr.App.Client --outDir ./src/SAFEr.App.Client/.fable-build --run vite",

--- a/src/default/postcss.config.js
+++ b/src/default/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     plugins: {
         tailwindcss: {},
         autoprefixer: {},

--- a/src/default/tailwind.config.js
+++ b/src/default/tailwind.config.js
@@ -1,7 +1,7 @@
 import daisyui from "daisyui";
 export default {
     content: [
-        "./src/FastRefresher2.Client/.fable-build/**/*.{js,ts,jsx,tsx}",
+        "./src/SAFEr.App.Client/.fable-build/**/*.{js,ts,jsx,tsx}",
     ],
     plugins: [
         daisyui,

--- a/src/default/tailwind.config.js
+++ b/src/default/tailwind.config.js
@@ -1,8 +1,9 @@
-module.exports = {
+import daisyui from "daisyui";
+export default {
     content: [
-        "./src/SAFEr.App.Client/.fable-build/**/*.{js,ts,jsx,tsx}",
+        "./src/FastRefresher2.Client/.fable-build/**/*.{js,ts,jsx,tsx}",
     ],
     plugins: [
-        require('daisyui'),
+        daisyui,
     ]
 }

--- a/src/default/yarn.lock
+++ b/src/default/yarn.lock
@@ -505,7 +505,7 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@vitejs/plugin-react@4.2.0":
+"@vitejs/plugin-react@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.2.0.tgz#d71352b1a443c09c7aae8f278dd071ab3d9d8490"
   integrity sha512-+MHTH/e6H12kRp5HUkzOGqPMksezRMmW+TNzlh/QXfI8rRf6l2Z2yH/v12no1UvTwhZgEDMuQ7g7rrfMseU6FQ==


### PR DESCRIPTION
Hi @Dzoukr,

I forgot to update the project to `ESM` (`CJS` has been deprecated since the `5.0` version).
There is also an update of `yarn.lock` (somehow previous version missed the `caret` prefix).

Sorry for the trouble.